### PR TITLE
Fix google search text adventure link

### DIFF
--- a/sites/google-search-text-adventure.md
+++ b/sites/google-search-text-adventure.md
@@ -1,5 +1,5 @@
 ---
 title: "Google search for 'text adventure'"
-url: "https://www.google.com/search?q=text+adventure/"
+url: "https://www.google.com/search?q=text+adventure"
 thumbnail: "google-search-text-adventure.jpg"
 ---


### PR DESCRIPTION
The link to google adventure doesn't seems to work with the `/` at the end of the URL. It add a `/` at the end of the search.